### PR TITLE
Make layout public on ZSA's online configurator

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **Apollo** is my custom keyboard layout for the programmable ZSA Moonlander keyboard. It uses the DVORAK layout as a base for the letters while using custom layer keys for symbols. It's designed to be comfortable to type on for coding, gaming, and media creation.
 
-Check out the layout on ZSA's [online configurator](https://configure.zsa.io/moonlander/layouts/gdQQ7/latest/0).
+Check out the layout on ZSA's [online configurator](https://configure.zsa.io/moonlander/layouts/gdQQ7/latest/0). <- This layout is marked private so I can't acces it. Can you make it public?
 
 ## The Layout
 


### PR DESCRIPTION
I can't open an issue in this repo, hence I am trying to get your attention via a PR ;)

Thanks for sharing your keyboard layout. It looks great and I'd like to play around with it, but the link you provided shows me the error message that the layout is marked as private, so I can't reuse your work. (And I didn't find an option for importing source code).

Could you change the layout to public? Thanks!